### PR TITLE
Allow access to any link returned in a result

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  */
 const CHS = require('./lib/CompaniesHouseSearchService');
 const CHP = require('./lib/CompaniesHouseProfileService');
+const CHG = require('./lib/CompaniesHouseGenericService');
 
 class CompaniesHouseApi{
 
@@ -108,6 +109,21 @@ class CompaniesHouseApi{
                 if (!companyNumber)
                     reject('Please include a company number');
                 new CHP(this.apiKey).retrieveCompanyProfileBy(companyNumber).then(result => {
+                    resolve(result);
+                }).catch(err => {
+                    reject(err);
+                });
+            }
+        )
+    }
+
+    //#### Generic methods ####//
+    getLink(link){
+        return new Promise(
+            (resolve, reject) => {
+                if (!link)
+                    reject('Please include a link to GET');
+                new CHG(this.apiKey).getLink(link).then(result => {
                     resolve(result);
                 }).catch(err => {
                     reject(err);

--- a/lib/CompaniesHouseGenericService.js
+++ b/lib/CompaniesHouseGenericService.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2017, Will Evans.
+ * Licensed under the MIT License.
+ */
+const axios = require('axios');
+
+class CompaniesHouseGenericService {
+
+    constructor(apiKey){
+        this.apiKey = apiKey;
+    }
+
+    /**
+     * This method calls the companies house API to return data for a specific link e.g one returned in Company Profile
+     * @param link
+     * @return {Promise}
+     */
+    getLink(link){
+        return new Promise(
+            (resolve, reject) => {
+                axios({
+                    method:'get',
+                    url: `https://api.companieshouse.gov.uk${link}`,
+                    auth: {
+                        username: this.apiKey,
+                        password: ''
+                    }
+                }).then(result => {
+                    switch (result.status){
+                        case 200:
+                            resolve(result);
+                            break;
+                        case 404:
+                            reject('Sorry that link does not exist');
+                            break;
+                        default:
+                            reject('Sorry something has gone wrong');
+                    }
+                }).catch(err => {
+                    reject(err);
+                });
+            }
+        )
+    }
+
+}
+
+module.exports = CompaniesHouseGenericService;

--- a/lib/CompaniesHouseGenericService.js
+++ b/lib/CompaniesHouseGenericService.js
@@ -28,7 +28,7 @@ class CompaniesHouseGenericService {
                 }).then(result => {
                     switch (result.status){
                         case 200:
-                            resolve(result);
+                            resolve(result.data);
                             break;
                         case 404:
                             reject('Sorry that link does not exist');

--- a/lib/CompaniesHouseProfileService.js
+++ b/lib/CompaniesHouseProfileService.js
@@ -28,7 +28,7 @@ class CompaniesHouseProfileService {
                 }).then(result => {
                     switch (result.status){
                         case 200:
-                            resolve(result);
+                            resolve(result.data);
                             break;
                         case 404:
                             reject('Sorry no results match that company number');

--- a/lib/CompaniesHouseProfileService.js
+++ b/lib/CompaniesHouseProfileService.js
@@ -15,16 +15,13 @@ class CompaniesHouseProfileService {
      * @param companyNumber
      * @return {Promise}
      */
-    retrieveCompanyProfileBy(companyNumber){
+    retrieveCompanyProfileBy(companyNumber) {
         return new Promise(
             (resolve, reject) => {
                 axios({
                     method:'get',
-                    url: 'https://api.companieshouse.gov.uk/company',
-                    params: {
-                        company_number: companyNumber
-                    },
-                    auth:{
+                    url: `https://api.companieshouse.gov.uk/company/${companyNumber}`,
+                    auth: {
                         username: this.apiKey,
                         password: ''
                     }

--- a/lib/CompaniesHouseProfileService.js
+++ b/lib/CompaniesHouseProfileService.js
@@ -15,7 +15,7 @@ class CompaniesHouseProfileService {
      * @param companyNumber
      * @return {Promise}
      */
-    retrieveCompanyProfileBy(companyNumber) {
+    retrieveCompanyProfileBy(companyNumber){
         return new Promise(
             (resolve, reject) => {
                 axios({


### PR DESCRIPTION
Fixes to readCompanyProfile
Add ability to get a specific link for example when a profile returns a link to officers, you can then get that linl.