### PR TITLE
Return empty items instead of throwing an error

### DIFF
--- a/lib/CompaniesHouseSearchService.js
+++ b/lib/CompaniesHouseSearchService.js
@@ -21,7 +21,8 @@ class CompaniesHouseSearchService {
                     method:'get',
                     url: 'https://api.companieshouse.gov.uk/search/companies',
                     params: {
-                        q: id
+                        q: id,
+                        items_per_page: 1
                     },
                     auth:{
                         username: this.apiKey,
@@ -33,12 +34,12 @@ class CompaniesHouseSearchService {
                     reject(err);
                 });
             }
-        )
+        );
     }
 
     /**
      * This method queries the Companies House API for a generic query. Returns an array of companies which you can limit.
-     * @param id
+     * @param query
      * @param itemCount
      * @returns {Promise}
      */
@@ -57,12 +58,12 @@ class CompaniesHouseSearchService {
                         password: ''
                     }
                 }).then(result => {
-                    result.data.items.length > 0 ? resolve(result.data.items) : reject('Sorry no results match your search');
+                    resolve(result.data.items);
                 }).catch(err => {
                     reject(err);
                 });
             }
-        )
+        );
     }
 
     /**
@@ -86,12 +87,12 @@ class CompaniesHouseSearchService {
                         password: ''
                     }
                 }).then(result => {
-                    result.data.items.length > 0 ? resolve(result.data.items) : reject('Sorry no results match your search');
+                    resolve(result.data.items);
                 }).catch(err => {
                     reject(err);
                 });
             }
-        )
+        );
     }
 
     /**


### PR DESCRIPTION
This does a few things:
- Fix some docblocks and missing semicolons
- limit the results from searchForCompanyBy to 1 for some optimisation
- Instead of throwing a string, return the items array for searchCompanyByGeneric and searchAllBy

The reasoning behind this is that throwing a string doesn't really make much sense, other services, packages and APIs usually return an empty array, or something along those lines.

Not throwing an error on no results makes this package much easier to work with.

E.g. just loop through the result, rather than having to check for a 'no results' string being thrown.