### PR TITLE
Handle 404 response properly

### DIFF
--- a/lib/CompaniesHouseProfileService.js
+++ b/lib/CompaniesHouseProfileService.js
@@ -28,19 +28,18 @@ class CompaniesHouseProfileService {
                 }).then(result => {
                     switch (result.status){
                         case 200:
-                            resolve(result.data);
-                            break;
-                        case 404:
-                            reject('Sorry no results match that company number');
-                            break;
+                            return resolve(result.data);
                         default:
-                            reject('Sorry something has gone wrong');
+                            return reject('Sorry something has gone wrong');
                     }
                 }).catch(err => {
-                    reject(err);
+                    if (err.response && err.response.status === 404) {
+                        return reject('Sorry no results match that company number');
+                    }
+                    return reject(err);
                 });
             }
-        )
+        );
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "companies-house-api-es6",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "This service will do a companies house lookup for a registered UK company",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Axios throws an error when getting a 404 response

I moved the code which checks the status into the catch, instead of the `.then` (as this code will never hit)